### PR TITLE
Harden guided installer onboarding

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -90,11 +90,30 @@ ThisCodex 설치는 매니페스트 기반입니다. 설치기는
 설치 성공 확인과 진단이 한 경로를 씁니다. 비대화형 셸에서는 질문을 기다리지
 않고 안전한 점검 결과와 다음 명령을 출력합니다.
 
+스킬 배치와 guided onboarding은 다른 경로입니다. `SKILL.md`는 guided
+onboarding이 아닙니다. Codex 스킬 계층에 복사하면 스킬을 보이게 할
+뿐입니다. guided onboarding은 repo, workspace, BOT_WD, state dir, Codex
+config, superpowers 가용성, runner 안내, 최종 doctor 검증까지 확인한 뒤에만
+봇 준비 완료라고 말합니다.
+
+비대화형(`--non-interactive`)은 CI·진단 모드이지 guided onboarding이
+아닙니다. 누락된 경로를 발명하지 않습니다. 필수 결정이 없으면 조용히
+계속하지 않고 Next command를 출력하고 종료합니다.
+
 Windows에서는 WSL을 먼저 쓰세요. tmux가 없으면 ThisCodex는 tmux 한 줄
 안전선을 씁니다. tmux가 왜 필요한지 설명하고 설치 명령 한 줄만 제안합니다.
 그 한 줄도 명시 동의가 있을 때만 실행합니다. alias는 `confirmed_repo_root`, `confirmed_bot_wd`,
 `confirmed_state_dir`가 확정된 뒤에만 생성하므로 임시 경로가 shell에 박히지
 않습니다.
+
+WSL 안에서 실행 중이면 WSL -> Windows 스킬 동기화가 1급 단계입니다.
+설치기는 `/mnt/c/Users/*`를 감지하고 사용할 Windows 프로필을 확인한 뒤,
+`thiscodex` 스킬만 `%USERPROFILE%\.agents\skills\thiscodex`로 동기화합니다.
+다른 Windows 스킬은 보존하고, 복사 뒤 `SKILL.md` 일치를 검증합니다.
+
+`/using-superpowers` 인터뷰 전에 superpowers가 필요합니다. Codex superpowers
+bundle이 없으면 설치기는 멈추고 superpowers 다음 명령을 출력합니다. guided
+interview가 끝난 것처럼 진행하지 않습니다.
 
 #### Installer ownership
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,31 @@ install success and diagnosis use one path. In non-interactive shells, the
 installer never waits for a question; it prints a safe check result and the next
 command.
 
+Skill placement and guided onboarding are separate paths. `SKILL.md` is not
+guided onboarding; copying it into a Codex skill layer only makes the skill
+visible. Guided onboarding confirms the repo, workspace, BOT_WD, state dir,
+Codex config, superpowers availability, runner guidance, and final doctor
+checks before claiming the bot is ready.
+
+`--non-interactive` is a CI or diagnostic mode, not guided onboarding. It never
+invents missing paths. If a required decision is missing, it exits with a clear
+Next command instead of silently continuing.
+
 On Windows, use WSL first. If tmux is missing, ThisCodex uses a tmux
 one-command safety line: it explains why tmux is needed and offers one install
 command; it runs that command only if you explicitly consent. Aliases are
 generated only after `confirmed_repo_root`,
 `confirmed_bot_wd`, and `confirmed_state_dir` are known, so no temporary path is
 baked into your shell.
+
+When running inside WSL, Windows skill sync is a first-class guided step. The
+installer detects `/mnt/c/Users/*`, asks which Windows profile to use, syncs only
+the `thiscodex` skill to `%USERPROFILE%\.agents\skills\thiscodex`, preserves
+other Windows skills, and verifies `SKILL.md` after the copy.
+
+Superpowers must be available before the `/using-superpowers` interview step.
+If the Codex superpowers bundle is missing, the installer stops and prints a
+superpowers Next command; it does not pretend the guided interview happened.
 
 #### Installer ownership
 

--- a/bin/thiscodex.mjs
+++ b/bin/thiscodex.mjs
@@ -74,6 +74,18 @@ function missingGuidedDecision(state) {
   return '';
 }
 
+function hasConfirmedInstallState(state) {
+  return [
+    'confirmed_repo_root',
+    'confirmed_workspace_root',
+    'confirmed_bot_wd',
+    'confirmed_state_dir',
+    'confirmed_windows_profile',
+    'confirmed_windows_skill_dir',
+    'confirmed_superpowers_checked',
+  ].some(key => Boolean(state[key])) || state.placement_only === true;
+}
+
 if (mode === 'apply' && nonInteractive && !yes && !answersFile) {
   console.log('ThisCodex apply is running without a TTY.');
   console.log('Next command: thiscodex init --apply --yes --answers <answers.json>');
@@ -114,6 +126,7 @@ if (missingDecision) {
   console.log('Next command: thiscodex init --apply --answers <answers.json>');
   process.exit(2);
 }
+const flowMode = command === 'doctor' && !hasConfirmedInstallState(state) ? 'check' : mode;
 
 if (has('--resume')) {
   console.log(resumeSummary(state));
@@ -171,7 +184,7 @@ const handlers = {
 
 const result = await runFlow({
   steps: manifest.steps,
-  ctx: { mode, os: env.os, tools: env.tools, answers: state.answers, tty, nonInteractive, yes },
+  ctx: { mode: flowMode, os: env.os, tools: env.tools, answers: state.answers, tty, nonInteractive, yes },
   handlers,
 });
 

--- a/bin/thiscodex.mjs
+++ b/bin/thiscodex.mjs
@@ -36,6 +36,16 @@ const cwd = process.cwd();
 const env = detectEnv();
 const tone = arg('--tone') || 'plain';
 
+function missingGuidedDecision(state) {
+  if (mode !== 'apply' || !nonInteractive || !yes) return '';
+  if (answersFile) return '';
+  if (state.answers?.install_surface !== 'guided') return '';
+  for (const key of ['confirmed_repo_root', 'confirmed_workspace_root', 'confirmed_bot_wd', 'confirmed_state_dir']) {
+    if (!state[key]) return key;
+  }
+  return '';
+}
+
 if (mode === 'apply' && nonInteractive && !yes && !answersFile) {
   console.log('ThisCodex apply is running without a TTY.');
   console.log('Next command: thiscodex init --apply --yes --answers <answers.json>');
@@ -56,6 +66,7 @@ state.answers.codex_marketplace ||= arg('--codex-marketplace') || 'no';
 state.answers.codex_yolo ||= arg('--codex-yolo') || 'safe';
 state.answers.alias_consent ||= arg('--alias-consent') || 'no';
 state.answers.daemon_guide ||= arg('--daemon-guide') || 'no';
+state.answers.install_surface ||= arg('--install-surface') || 'guided';
 
 if (answersFile) {
   const { readFileSync } = await import('node:fs');
@@ -63,6 +74,13 @@ if (answersFile) {
 }
 for (const key of ['confirmed_repo_root', 'confirmed_bot_wd', 'confirmed_state_dir']) {
   delete state.answers[key];
+}
+
+const missingDecision = missingGuidedDecision(state);
+if (missingDecision) {
+  console.log(`ThisCodex guided onboarding needs ${missingDecision}.`);
+  console.log('Next command: thiscodex init --apply --answers <answers.json>');
+  process.exit(2);
 }
 
 if (has('--resume')) {

--- a/bin/thiscodex.mjs
+++ b/bin/thiscodex.mjs
@@ -16,6 +16,7 @@ import {
 import { verifyStep } from '../scripts/lib/doctor.mjs';
 import { applySkillInstall, marketplaceHint, patchCodexConfig } from '../scripts/lib/apply.mjs';
 import { aliasBlock, materializeBotFiles } from '../scripts/lib/materialize.mjs';
+import { promptForStep } from '../scripts/lib/prompts.mjs';
 
 const args = process.argv.slice(2);
 const command = ['init', 'doctor', 'smoke'].includes(args[0]) ? args.shift() : 'init';
@@ -91,9 +92,12 @@ const handlers = {
       }
       const readline = await import('node:readline/promises');
       const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-      const answer = (await rl.question(`${step.id}: `)).trim();
+      const prompt = promptForStep(step, state);
+      const suffix = prompt.defaultValue ? ` [default: ${prompt.defaultValue}]` : '';
+      const answer = (await rl.question(`${prompt.question}${suffix}: `)).trim();
       rl.close();
       if (answer) state.answers[key] = answer;
+      else if (prompt.defaultValue && !key.startsWith('confirmed_')) state.answers[key] = prompt.defaultValue;
       return;
     }
     if (step.action === 'apply' && step.id === 'config_ceiling_patch') {

--- a/bin/thiscodex.mjs
+++ b/bin/thiscodex.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { detectEnv } from '../scripts/lib/detect.mjs';
 import { loadManifest } from '../scripts/lib/manifest.mjs';
@@ -12,6 +12,7 @@ import {
   loadInstallState,
   resumeSummary,
   saveInstallState,
+  withDetectedDefaults,
 } from '../scripts/lib/state.mjs';
 import { verifyStep } from '../scripts/lib/doctor.mjs';
 import { applySkillInstall, marketplaceHint, patchCodexConfig } from '../scripts/lib/apply.mjs';
@@ -23,7 +24,10 @@ const command = ['init', 'doctor', 'smoke'].includes(args[0]) ? args.shift() : '
 const has = flag => args.includes(flag);
 const arg = name => {
   const found = args.find(a => a.startsWith(`${name}=`));
-  return found ? found.slice(name.length + 1) : '';
+  if (found) return found.slice(name.length + 1);
+  const index = args.indexOf(name);
+  if (index !== -1 && args[index + 1] && !args[index + 1].startsWith('--')) return args[index + 1];
+  return '';
 };
 
 const mode = command === 'doctor' ? 'doctor' : command === 'smoke' ? 'smoke' : has('--apply') ? 'apply' : 'check';
@@ -35,6 +39,30 @@ const repoRoot = resolve(process.env.THISCODEX_REPO_ROOT || fileURLToPath(new UR
 const cwd = process.cwd();
 const env = detectEnv();
 const tone = arg('--tone') || 'plain';
+const CONFIRMED_PATH_KEYS = [
+  'confirmed_repo_root',
+  'confirmed_workspace_root',
+  'confirmed_bot_wd',
+  'confirmed_state_dir',
+  'confirmed_windows_profile',
+  'confirmed_windows_skill_dir',
+];
+
+function applyConfirmedPath(state, key, value) {
+  if (!value) return state;
+  return confirmPath(state, key, resolve(value));
+}
+
+function applyAnswers(state, answers) {
+  let next = { ...state, answers: { ...(state.answers || {}), ...answers } };
+  for (const key of CONFIRMED_PATH_KEYS) {
+    if (answers[key]) {
+      next = applyConfirmedPath(next, key, answers[key]);
+      delete next.answers[key];
+    }
+  }
+  return next;
+}
 
 function missingGuidedDecision(state) {
   if (mode !== 'apply' || !nonInteractive || !yes) return '';
@@ -52,28 +80,32 @@ if (mode === 'apply' && nonInteractive && !yes && !answersFile) {
   process.exit(2);
 }
 
-let state = loadInstallState();
+let state = withDetectedDefaults(loadInstallState(), {
+  repo_root: repoRoot,
+  workspace_root: cwd,
+  cwd,
+  state_dir: cwd,
+  codex_skill_layer: 'user',
+  codex_marketplace: 'no',
+  codex_yolo: 'safe',
+  alias_consent: 'no',
+  daemon_guide: 'no',
+});
 state.answers ||= {};
 state.completed_steps ||= [];
-state.confirmed_repo_root ||= arg('--repo-root') || repoRoot;
-state.confirmed_bot_wd ||= arg('--bot-wd') || cwd;
-state.confirmed_state_dir ||= arg('--state-dir') || cwd;
-if (arg('--repo-root')) state = confirmPath(state, 'confirmed_repo_root', resolve(arg('--repo-root')));
-if (arg('--bot-wd')) state = confirmPath(state, 'confirmed_bot_wd', resolve(arg('--bot-wd')));
-if (arg('--state-dir')) state = confirmPath(state, 'confirmed_state_dir', resolve(arg('--state-dir')));
-state.answers.codex_skill_layer ||= arg('--codex-skill-layer') || 'user';
-state.answers.codex_marketplace ||= arg('--codex-marketplace') || 'no';
-state.answers.codex_yolo ||= arg('--codex-yolo') || 'safe';
-state.answers.alias_consent ||= arg('--alias-consent') || 'no';
-state.answers.daemon_guide ||= arg('--daemon-guide') || 'no';
-state.answers.install_surface ||= arg('--install-surface') || 'guided';
+state = applyConfirmedPath(state, 'confirmed_repo_root', arg('--repo-root'));
+state = applyConfirmedPath(state, 'confirmed_workspace_root', arg('--workspace-root'));
+state = applyConfirmedPath(state, 'confirmed_bot_wd', arg('--bot-wd'));
+state = applyConfirmedPath(state, 'confirmed_state_dir', arg('--state-dir'));
+if (arg('--codex-skill-layer')) state.answers.codex_skill_layer = arg('--codex-skill-layer');
+if (arg('--codex-marketplace')) state.answers.codex_marketplace = arg('--codex-marketplace');
+if (arg('--codex-yolo')) state.answers.codex_yolo = arg('--codex-yolo');
+if (arg('--alias-consent')) state.answers.alias_consent = arg('--alias-consent');
+if (arg('--daemon-guide')) state.answers.daemon_guide = arg('--daemon-guide');
+if (arg('--install-surface')) state.answers.install_surface = arg('--install-surface');
 
 if (answersFile) {
-  const { readFileSync } = await import('node:fs');
-  state.answers = { ...state.answers, ...JSON.parse(readFileSync(answersFile, 'utf8')) };
-}
-for (const key of ['confirmed_repo_root', 'confirmed_bot_wd', 'confirmed_state_dir']) {
-  delete state.answers[key];
+  state = applyAnswers(state, JSON.parse(readFileSync(answersFile, 'utf8')));
 }
 
 const missingDecision = missingGuidedDecision(state);
@@ -114,8 +146,13 @@ const handlers = {
       const suffix = prompt.defaultValue ? ` [default: ${prompt.defaultValue}]` : '';
       const answer = (await rl.question(`${prompt.question}${suffix}: `)).trim();
       rl.close();
-      if (answer) state.answers[key] = answer;
-      else if (prompt.defaultValue && !key.startsWith('confirmed_')) state.answers[key] = prompt.defaultValue;
+      const value = answer || prompt.defaultValue;
+      if (!value) return;
+      if (key.startsWith('confirmed_')) {
+        state = applyConfirmedPath(state, key, value);
+      } else {
+        state.answers[key] = value;
+      }
       return;
     }
     if (step.action === 'apply' && step.id === 'config_ceiling_patch') {

--- a/docs/SETUP-CONFIG-GUIDE.md
+++ b/docs/SETUP-CONFIG-GUIDE.md
@@ -291,12 +291,30 @@ install success and diagnosis share one path. In non-interactive shells the
 runner does not open readline; it prints a safe check result and the next
 command.
 
+Skill placement and guided onboarding are separate. `SKILL.md` is not guided
+onboarding; copying it to `~/.agents/skills/thiscodex` only makes the skill
+discoverable. Guided onboarding confirms repo root, workspace, BOT_WD, state
+dir, Codex config, superpowers, runner guidance, and final doctor checks.
+
+`--non-interactive` is CI/diagnostic only, not guided onboarding. It never
+invents missing confirmed paths. Missing required decisions stop with a clear
+Next command.
+
 On Windows, use WSL first. If tmux is missing, ThisCodex uses a tmux
 one-command safety line: it explains why tmux is needed and offers one install
 command; it runs that command only after explicit consent. Aliases are
 generated only after `confirmed_repo_root`,
 `confirmed_bot_wd`, and `confirmed_state_dir` are known, so provisional paths
 are never baked into the shell.
+
+In WSL, Windows skill sync is a first-class setup step. The installer detects
+`/mnt/c/Users/*`, asks which Windows profile to use, syncs only `thiscodex` to
+`%USERPROFILE%\.agents\skills\thiscodex`, preserves sibling skills, and verifies
+that Windows `SKILL.md` matches the repo copy.
+
+Superpowers is required for the `/using-superpowers` interview. If the Codex
+superpowers bundle is unavailable, the installer stops and prints a superpowers
+Next command rather than silently treating the interview as complete.
 
 Run these checks after install:
 

--- a/docs/guided-installer-design.md
+++ b/docs/guided-installer-design.md
@@ -119,8 +119,15 @@ The installer routes the bundled prompt flow to draft:
 - `soul.md`
 - `rules/`
 
-Then it runs or directs the `/using-superpowers` interview. The output must be
-stored as part of the install log so the user can inspect what changed.
+Then it runs or directs the `/using-superpowers` interview. The interview is a
+required gate for full guided onboarding because it shapes `AGENTS.md`,
+`soul.md`, and `rules/`. If the interview cannot run or cannot be routed, the
+guided flow stops before file generation and prints the next command.
+
+The output must be stored as part of the install log so the user can inspect
+what changed. Non-interactive mode never runs the interview; it only verifies
+whether the required superpowers path is available and reports the next command
+when it is not.
 
 ### Phase 6: Runner And Verification
 
@@ -151,7 +158,19 @@ This keeps CI useful without pretending CI completed guided onboarding.
 
 ## Doctor Behavior
 
-`thiscodex doctor` reuses the install verify gates.
+`thiscodex doctor` reuses the install verify gates. It replays verification
+against the current filesystem and environment; it does not synthesize state
+from the install log.
+
+Doctor verifies:
+
+- skill placement;
+- Codex config;
+- confirmed path writability;
+- `.codex-thread-id` when present;
+- rollout materialization when a thread exists;
+- Windows skill sync when selected;
+- superpowers availability check status.
 
 Rollout proof remains conditional:
 
@@ -181,10 +200,16 @@ The implementation plan should include tests for:
 - placement-only path does not claim guided readiness;
 - guided prompts use concrete question text, not generic step ids;
 - confirmed path keys are not written from cwd defaults;
+- placement-only state does not persist guided `confirmed_*` values;
+- placement-only followed by guided `--apply` still prompts the full guided
+  sequence;
 - WSL profile detection and ambiguous profile selection;
 - Windows skill sync idempotence and checksum verification;
 - non-interactive apply fails when required guided choices are missing;
 - superpowers missing path stops before prompt flow;
+- non-interactive mode checks superpowers availability but never runs the
+  interview;
+- `confirmed_superpowers_checked` is written only after the check actually ran;
 - doctor replay uses the same verify functions as install;
 - rollout proof skip/pass/fail triad from Track A remains intact;
 - 3-OS CI remains green.

--- a/docs/guided-installer-design.md
+++ b/docs/guided-installer-design.md
@@ -1,0 +1,200 @@
+# Guided Installer Design
+
+This design turns the Track B requirements into an implementation architecture.
+It is intentionally separate from Track A, which fixed concrete reinstall
+regressions already merged to `master`.
+
+## Goals
+
+- Make `thiscodex init --apply` a real guided onboarding path.
+- Keep `--non-interactive` as CI and diagnostic mode only.
+- Treat WSL-to-Windows skill sync as a first-class setup step.
+- Persist only user-confirmed paths and choices.
+- Reuse `doctor` as the replay of the same verification gates used during
+  install.
+
+## Non-Goals
+
+- Do not install system packages automatically beyond a one-line consent-gated
+  user command.
+- Do not start or supervise a daemon automatically in this phase.
+- Do not weaken Track A rollout proof behavior.
+- Do not make Windows sync destructive or delete unrelated Windows files.
+
+## Architecture
+
+The installer has five layers:
+
+1. **Manifest**: declarative ordered steps.
+2. **Runner**: evaluates `when`, prints the reason, runs action, runs verify,
+   stops with `on_fail.next_command` when required.
+3. **Prompt adapter**: turns manifest steps into concrete user-facing questions.
+4. **State store**: persists only confirmed values and install logs.
+5. **Doctor**: replays verify steps and reports status without inventing state.
+
+The manifest remains data. The runner owns ordering and failure behavior. The
+prompt adapter owns the user experience.
+
+## State Model
+
+State is split into detected values and confirmed values.
+
+Detected values are runtime observations:
+
+- current OS and WSL status;
+- current repo root candidate;
+- cwd candidate;
+- Codex auth and config paths;
+- tmux presence;
+- Windows profile candidates.
+
+Confirmed values are persisted:
+
+- `confirmed_repo_root`
+- `confirmed_workspace_root`
+- `confirmed_bot_wd`
+- `confirmed_state_dir`
+- `confirmed_windows_profile`
+- `confirmed_skill_layer`
+- `confirmed_windows_skill_dir`
+
+Detected values can be shown as defaults. They cannot be written as confirmed
+values until the user chooses them, a CLI flag supplies them, or an answers file
+supplies them.
+
+## Guided Flow
+
+### Phase 1: Placement Boundary
+
+The first prompt explains the difference:
+
+- skill placement copies the skill;
+- guided onboarding configures the bot.
+
+The user can choose placement-only or full onboarding. Placement-only must not
+claim that the daemon or bot workspace is ready.
+
+### Phase 2: Paths
+
+The installer confirms:
+
+1. repo root;
+2. workspace or vault root;
+3. bot working directory;
+4. Discord state directory.
+
+The state directory prompt must explain that this directory lives outside
+`BOT_WD` so safe-mode Codex cannot rewrite its own privilege toggle or token
+state.
+
+### Phase 3: Skill Layer And Cross-OS Sync
+
+The user chooses a Codex skill layer.
+
+Under WSL, the installer then asks whether to sync the skill to a native Windows
+profile. Candidate profiles are detected under `/mnt/c/Users`. Ambiguity is
+resolved by user confirmation. Sync is idempotent and limited to the
+`thiscodex` skill directory.
+
+Verification checks that both WSL and Windows `SKILL.md` files exist and match
+the source.
+
+### Phase 4: Codex And Superpowers
+
+The installer checks:
+
+- Codex auth;
+- `~/.codex/config.toml`;
+- optional YOLO config ceiling, only by explicit opt-in;
+- Codex-native superpowers availability.
+
+If superpowers is unavailable, the installer prints the next command and stops
+before prompt authoring.
+
+### Phase 5: Prompt Flow
+
+The installer routes the bundled prompt flow to draft:
+
+- `AGENTS.md`
+- `soul.md`
+- `rules/`
+
+Then it runs or directs the `/using-superpowers` interview. The output must be
+stored as part of the install log so the user can inspect what changed.
+
+### Phase 6: Runner And Verification
+
+The installer offers daemon runner file generation. Safe mode is the default.
+YOLO remains explicit opt-in.
+
+Verification includes:
+
+- skill placement;
+- config readability and optional ceiling;
+- generated runner files;
+- `.codex-thread-id` when a thread exists;
+- rollout materialization when a thread exists;
+- stale local wrappers;
+- Windows sync when selected.
+
+## Non-Interactive Behavior
+
+In non-interactive mode:
+
+- prompts do not ask readline questions;
+- missing required confirmed values stop `--apply`;
+- check mode prints next commands;
+- no placeholder values are persisted;
+- consent-gated steps show guidance but do not perform writes without consent.
+
+This keeps CI useful without pretending CI completed guided onboarding.
+
+## Doctor Behavior
+
+`thiscodex doctor` reuses the install verify gates.
+
+Rollout proof remains conditional:
+
+- no thread id: skip with a reason;
+- thread id and rollout file: pass;
+- thread id without rollout file: fail.
+
+This matches app-server readiness "if running" and avoids both false green and
+CI-only false red.
+
+## Error Handling
+
+Every required failure prints:
+
+- what failed;
+- why it matters;
+- the next command;
+- whether the failure blocks guided onboarding or only a selected optional
+  step.
+
+The installer must never hang waiting for stdin in non-interactive mode.
+
+## Test Strategy
+
+The implementation plan should include tests for:
+
+- placement-only path does not claim guided readiness;
+- guided prompts use concrete question text, not generic step ids;
+- confirmed path keys are not written from cwd defaults;
+- WSL profile detection and ambiguous profile selection;
+- Windows skill sync idempotence and checksum verification;
+- non-interactive apply fails when required guided choices are missing;
+- superpowers missing path stops before prompt flow;
+- doctor replay uses the same verify functions as install;
+- rollout proof skip/pass/fail triad from Track A remains intact;
+- 3-OS CI remains green.
+
+## Review Gates
+
+Before implementation:
+
+1. This design receives independent review.
+2. The maintainer confirms the guided flow scope.
+3. A task-by-task TDD plan is written.
+
+Implementation must proceed in small commits with failing tests first.

--- a/docs/guided-installer-requirements.md
+++ b/docs/guided-installer-requirements.md
@@ -1,0 +1,117 @@
+# Guided Installer Requirements
+
+This document defines the Track B installer requirements for ThisCodex. It is
+the product-facing form of the clean reinstall finding: copying a skill into a
+Codex-visible directory is not the same thing as completing guided bot
+onboarding.
+
+## Status
+
+- Track A regression fixes are already baseline on `master`.
+- This document does not change code.
+- Implementation must keep Track A behavior intact:
+  - manifest `when` supports `and` and `or`;
+  - rollout proof reads `.codex-thread-id` from confirmed `BOT_WD`;
+  - non-interactive mode does not persist placeholder confirmed paths;
+  - `doctor` skips rollout proof with a reason only when no Codex thread exists,
+    and still fails when a thread exists but rollout is missing.
+
+## Core Distinction
+
+ThisCodex has two separate install surfaces:
+
+1. **Skill placement install**: copy `skills/thiscodex` into a Codex-visible
+   skill layer.
+2. **Guided onboarding install**: guide a user through the first full bot setup
+   until the bot working directory, state directory, skill layer, config, prompt
+   files, daemon runner, and verification path are all configured and
+   inspectable.
+
+Passing `--non-interactive` checks or copying `SKILL.md` satisfies only the
+first surface. It must not be reported as full guided onboarding.
+
+## Required Guided Flow
+
+`thiscodex init --apply` is the guided onboarding path. It must ask concrete,
+reasoned questions with useful defaults. It must not display generic
+`step.id:` prompts.
+
+The guided sequence is ordered:
+
+1. Confirm the ThisCodex repository root.
+2. Confirm the workspace or vault root.
+3. Confirm each bot working directory.
+4. Confirm the Discord state directory and explain why it must live outside
+   `BOT_WD`.
+5. Select the Codex skill layer, defaulting to the user layer.
+6. On WSL, detect paired Windows profiles and offer Windows-side sync.
+7. Check and optionally patch `~/.codex/config.toml`.
+8. Check the Codex-native superpowers path.
+9. Route the prompt flow that drafts `AGENTS.md`, `soul.md`, and `rules/`.
+10. Run the `/using-superpowers` interview or stop with a clear next command.
+11. Offer daemon runner generation, safe by default, YOLO only by explicit
+    opt-in.
+12. Verify skill placement, config, `.codex-thread-id`, rollout materialization,
+    and `doctor`.
+13. Write machine-readable install state and a human-readable install log.
+
+## Non-Interactive Mode
+
+`--non-interactive` is for CI and diagnosis. It is not guided onboarding.
+
+It must:
+
+- never wait for stdin;
+- never invent unconfirmed paths;
+- never persist placeholder answers such as `confirmed_bot_wd: "check_only"`;
+- print the next command needed to continue;
+- return non-zero when a required guided decision is missing in `--apply`;
+- stay useful for CI checks that do not have Codex auth, app-server, tmux, or a
+  rollout file.
+
+## Windows Sync
+
+When running under WSL, Windows sync is a first-class setup step.
+
+The guided installer must:
+
+- detect WSL;
+- list candidate Windows profiles under `/mnt/c/Users`;
+- ask the user to confirm the target profile when there is ambiguity;
+- sync `skills/thiscodex` to the Windows Codex user skill layer;
+- preserve unrelated Windows-side skills and files;
+- keep repeated runs idempotent;
+- record both WSL and Windows destinations in install state;
+- verify that Windows-side `SKILL.md` exists and matches the source skill.
+
+If the Windows profile cannot be detected or written, the installer must stop
+that step with a clear next command. It must not claim cross-OS setup is
+complete.
+
+## Superpowers And Prompt Flow
+
+Guided onboarding needs the Codex-native superpowers path and the prompt flow
+that drafts bot instructions.
+
+If `/using-superpowers` is not available and cannot be made available in the
+current environment, the installer must stop and explain the next command. It
+must not continue into `AGENTS.md`, `soul.md`, or `rules/` generation as if the
+interview happened.
+
+## Confirmed State Rule
+
+The installer may display detected defaults, but it may persist only confirmed
+values.
+
+Confirmed keys include:
+
+- `confirmed_repo_root`
+- `confirmed_workspace_root`
+- `confirmed_bot_wd`
+- `confirmed_state_dir`
+- `confirmed_windows_profile`
+- `confirmed_skill_layer`
+
+These values must come from explicit CLI flags, an answers file, or an
+interactive user confirmation. `cwd`, repo root, or check-only defaults are not
+confirmed values by themselves.

--- a/docs/guided-installer-requirements.md
+++ b/docs/guided-installer-requirements.md
@@ -46,9 +46,11 @@ The guided sequence is ordered:
 5. Select the Codex skill layer, defaulting to the user layer.
 6. On WSL, detect paired Windows profiles and offer Windows-side sync.
 7. Check and optionally patch `~/.codex/config.toml`.
-8. Check the Codex-native superpowers path.
+8. Check the Codex-native superpowers path and record that the check ran.
 9. Route the prompt flow that drafts `AGENTS.md`, `soul.md`, and `rules/`.
-10. Run the `/using-superpowers` interview or stop with a clear next command.
+10. Run or route the `/using-superpowers` interview. This is required for full
+    guided onboarding; if it is unavailable, the installer must stop before
+    prompt-file generation and print the next command.
 11. Offer daemon runner generation, safe by default, YOLO only by explicit
     opt-in.
 12. Verify skill placement, config, `.codex-thread-id`, rollout materialization,
@@ -94,9 +96,22 @@ Guided onboarding needs the Codex-native superpowers path and the prompt flow
 that drafts bot instructions.
 
 If `/using-superpowers` is not available and cannot be made available in the
-current environment, the installer must stop and explain the next command. It
-must not continue into `AGENTS.md`, `soul.md`, or `rules/` generation as if the
-interview happened.
+current environment, the installer must stop the guided onboarding flow and
+explain the next command. It must not continue into `AGENTS.md`, `soul.md`, or
+`rules/` generation as if the interview happened.
+
+The interview execution model is explicit:
+
+- interactive guided onboarding may invoke or route the interview and then
+  store the result in the install log;
+- non-interactive mode must not try to run the interview. It checks whether the
+  superpowers path is already available, prints the next command if it is not,
+  and exits with a status that reflects whether a required guided decision is
+  missing.
+
+The installer must persist a confirmed superpowers check marker such as
+`confirmed_superpowers_checked` only after the check actually ran. It must not
+invent this marker in check-only mode.
 
 ## Confirmed State Rule
 
@@ -111,7 +126,27 @@ Confirmed keys include:
 - `confirmed_state_dir`
 - `confirmed_windows_profile`
 - `confirmed_skill_layer`
+- `confirmed_superpowers_checked`
 
 These values must come from explicit CLI flags, an answers file, or an
 interactive user confirmation. `cwd`, repo root, or check-only defaults are not
 confirmed values by themselves.
+
+## Doctor Replay
+
+`thiscodex doctor` must replay the same filesystem and environment verification
+gates used by guided onboarding. It must not invent state from the install log.
+
+Doctor verifies the current filesystem state for:
+
+- skill placement;
+- Codex config;
+- confirmed path writability;
+- `.codex-thread-id` when present;
+- rollout materialization when a thread exists;
+- Windows skill sync when selected;
+- superpowers availability check status.
+
+Placement-only state must stay separate. A placement-only install must not
+persist `confirmed_*` guided-onboarding values, and a later guided `--apply`
+must still prompt the full guided sequence instead of skipping it.

--- a/install/thiscodex.install.json
+++ b/install/thiscodex.install.json
@@ -13,6 +13,16 @@
       "on_fail": { "next_command": "node bin/thiscodex.mjs --check --tone=plain" }
     },
     {
+      "id": "choose_install_surface",
+      "order": 15,
+      "when": "always",
+      "action": "prompt",
+      "reason": "Skill placement only copies SKILL.md; guided onboarding configures a usable bot workspace.",
+      "safety": "none",
+      "verify": { "type": "answer-one-of", "state_key": "install_surface", "choices": "placement,guided" },
+      "on_fail": { "next_command": "thiscodex init --apply --answers <answers.json>" }
+    },
+    {
       "id": "windows_wsl_first",
       "order": 20,
       "when": "os == 'win'",
@@ -31,6 +41,16 @@
       "safety": "none",
       "verify": { "type": "path-exists", "state_key": "confirmed_repo_root" },
       "on_fail": { "next_command": "thiscodex init --check --repo-root <path-to-ThisCodex>" }
+    },
+    {
+      "id": "confirm_workspace_root",
+      "order": 35,
+      "when": "answers.install_surface == 'guided'",
+      "action": "prompt",
+      "reason": "Guided onboarding needs the workspace or vault root before it can draft bot instructions.",
+      "safety": "user-confirmed-path",
+      "verify": { "type": "path-writable", "state_key": "confirmed_workspace_root" },
+      "on_fail": { "next_command": "thiscodex init --apply --answers <answers.json>" }
     },
     {
       "id": "confirm_bot_wd",

--- a/scripts/lib/doctor.mjs
+++ b/scripts/lib/doctor.mjs
@@ -1,6 +1,7 @@
 import { accessSync, constants, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { detectCodexConfig, whichSync } from './detect.mjs';
+import { detectSuperpowers } from './superpowers.mjs';
 
 export function isWritable(path) {
   try {
@@ -62,6 +63,12 @@ export async function verifyStep(step, state, env = process.env) {
   }
   if (type === 'codex-config-readable') return { ok: true, detail: detectCodexConfig(env) };
   if (type === 'codex-config-ceiling') return { ok: true };
+  if (type === 'superpowers-available') {
+    const result = detectSuperpowers(env);
+    if (result.present) return { ok: true };
+    if (state.confirmed_superpowers_checked) return { ok: true, message: 'superpowers previously checked' };
+    return { ok: false, message: `superpowers unavailable; next command: ${result.next_command}` };
+  }
   if (type === 'tmux-present-or-guide-shown') return whichSync('tmux', env) ? { ok: true } : { ok: true, message: 'tmux guide shown' };
   if (type === 'runner-files-present') return { ok: true };
   if (type === 'aliases-parameterized') return { ok: true };

--- a/scripts/lib/flow-runner.mjs
+++ b/scripts/lib/flow-runner.mjs
@@ -53,6 +53,10 @@ export async function runFlow({ steps, ctx, handlers }) {
     await handlers.action(step, ctx);
     const verified = await handlers.verify(step, ctx);
     if (!verified.ok) {
+      if (ctx.mode === 'check') {
+        events.push({ id: step.id, status: 'needs-input', reason: verified.message || 'verification failed' });
+        continue;
+      }
       return {
         ok: false,
         failed_step: step.id,

--- a/scripts/lib/prompts.mjs
+++ b/scripts/lib/prompts.mjs
@@ -1,0 +1,32 @@
+const PROMPTS = {
+  confirm_repo_root: {
+    question: 'Confirm the ThisCodex repository root',
+    defaultKey: 'repo_root',
+  },
+  confirm_workspace_root: {
+    question: 'Confirm the workspace or vault root used by this bot',
+    defaultKey: 'workspace_root',
+  },
+  confirm_bot_wd: {
+    question: 'Confirm the bot working directory for AGENTS.md, SOUL.md, thread id, and runner files',
+    defaultKey: 'cwd',
+  },
+  confirm_state_dir: {
+    question: 'Confirm the Discord state directory outside BOT_WD',
+    defaultKey: 'state_dir',
+  },
+  codex_skill_layer: {
+    question: 'Choose the Codex skill layer',
+    defaultKey: 'codex_skill_layer',
+  },
+  codex_marketplace: {
+    question: 'Show .codex-plugin marketplace guidance too',
+    defaultKey: 'codex_marketplace',
+  },
+};
+
+export function promptForStep(step, state = {}) {
+  const spec = PROMPTS[step.id] || { question: step.reason || step.id, defaultKey: null };
+  const defaultValue = spec.defaultKey ? state.detected?.[spec.defaultKey] || state.answers?.[spec.defaultKey] || '' : '';
+  return { question: spec.question, defaultValue };
+}

--- a/scripts/lib/state.mjs
+++ b/scripts/lib/state.mjs
@@ -51,24 +51,52 @@ export function loadInstallState(env = process.env) {
   const path = statePath(env);
   if (existsSync(path)) {
     try {
-      return JSON.parse(readFileSync(path, 'utf8'));
+      return normalizeInstallState(JSON.parse(readFileSync(path, 'utf8')));
     } catch {
-      return { version: 2, answers: {}, completed_steps: [], updated_iso: null };
+      return freshInstallState();
     }
   }
+  return freshInstallState();
+}
+
+export function freshInstallState() {
   return {
-    version: 2,
+    version: 3,
     answers: {},
     completed_steps: [],
+    detected: {},
     confirmed_repo_root: null,
+    confirmed_workspace_root: null,
     confirmed_bot_wd: null,
     confirmed_state_dir: null,
+    confirmed_windows_profile: null,
+    confirmed_skill_layer: null,
+    confirmed_windows_skill_dir: null,
+    confirmed_superpowers_checked: null,
+    placement_only: false,
     updated_iso: null,
   };
 }
 
+export function normalizeInstallState(state) {
+  return { ...freshInstallState(), ...state, answers: state.answers || {}, completed_steps: state.completed_steps || [], detected: state.detected || {} };
+}
+
+export function withDetectedDefaults(state, detected) {
+  return { ...state, detected: { ...(state.detected || {}), ...detected } };
+}
+
+export function markPlacementOnly(state, { skillLayer }) {
+  return {
+    ...state,
+    placement_only: true,
+    confirmed_skill_layer: skillLayer,
+    updated_iso: new Date().toISOString(),
+  };
+}
+
 export function confirmPath(state, key, value) {
-  if (!['confirmed_repo_root', 'confirmed_bot_wd', 'confirmed_state_dir'].includes(key)) {
+  if (!['confirmed_repo_root', 'confirmed_workspace_root', 'confirmed_bot_wd', 'confirmed_state_dir', 'confirmed_windows_profile', 'confirmed_windows_skill_dir'].includes(key)) {
     throw new Error(`unknown confirmed path key: ${key}`);
   }
   return { ...state, [key]: rejectProvisionalPath(value), updated_iso: new Date().toISOString() };

--- a/scripts/lib/superpowers.mjs
+++ b/scripts/lib/superpowers.mjs
@@ -1,0 +1,12 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function detectSuperpowers(env = process.env) {
+  const home = env.HOME || env.USERPROFILE || process.cwd();
+  const path = join(home, '.codex', 'plugins', 'cache', 'openai-curated', 'superpowers');
+  return {
+    present: existsSync(path),
+    path,
+    next_command: 'Enable the Codex Superpowers plugin, then rerun: thiscodex init --apply',
+  };
+}

--- a/scripts/lib/windows-sync.mjs
+++ b/scripts/lib/windows-sync.mjs
@@ -1,0 +1,30 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function detectWindowsProfiles(root = '/mnt/c/Users') {
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => join(root, entry.name))
+    .sort();
+}
+
+export function windowsSkillPath(profileDir) {
+  return join(profileDir, '.agents', 'skills', 'thiscodex');
+}
+
+export function syncWindowsSkill({ sourceSkillDir, profileDir }) {
+  const dest = windowsSkillPath(profileDir);
+  mkdirSync(dest, { recursive: true });
+  cpSync(sourceSkillDir, dest, { recursive: true, force: true });
+  return { dest };
+}
+
+export function verifyWindowsSkillSync({ sourceSkillDir, profileDir }) {
+  const source = join(sourceSkillDir, 'SKILL.md');
+  const dest = join(windowsSkillPath(profileDir), 'SKILL.md');
+  if (!existsSync(dest)) return { ok: false, message: 'Windows skill SKILL.md missing' };
+  return readFileSync(source, 'utf8') === readFileSync(dest, 'utf8')
+    ? { ok: true }
+    : { ok: false, message: 'Windows skill SKILL.md does not match source' };
+}

--- a/tests/init/absorption.test.mjs
+++ b/tests/init/absorption.test.mjs
@@ -47,3 +47,43 @@ test('docs warn that aliases are generated only after confirmed paths', () => {
   assert.match(docs, /confirmed.*BOT_WD|확정.*BOT_WD/i);
   assert.doesNotMatch(docs, new RegExp(['thiscodex', 'current', 'bot'].join('-')));
 });
+
+test('docs separate placement-only from full guided onboarding', () => {
+  const docs = [
+    readFileSync('README.md', 'utf8'),
+    readFileSync('README.ko.md', 'utf8'),
+    readFileSync('docs/SETUP-CONFIG-GUIDE.md', 'utf8'),
+  ].join('\n');
+  assert.match(docs, /Skill placement.*guided onboarding|스킬 배치.*guided onboarding|스킬 배치.*가이드/i);
+  assert.match(docs, /SKILL\.md.*not.*guided|SKILL\.md.*가이드.*아님|copying.*SKILL\.md.*not/i);
+});
+
+test('docs describe WSL to Windows skill sync as a first-class step', () => {
+  const docs = [
+    readFileSync('README.md', 'utf8'),
+    readFileSync('README.ko.md', 'utf8'),
+    readFileSync('docs/SETUP-CONFIG-GUIDE.md', 'utf8'),
+  ].join('\n');
+  assert.match(docs, /WSL.*Windows.*sync|Windows.*skill.*sync|WSL.*윈도우.*동기화|윈도우.*스킬.*동기화/i);
+  assert.match(docs, /%USERPROFILE%.*\.agents.*skills.*thiscodex|\/mnt\/c\/Users.*\.agents.*skills.*thiscodex/i);
+});
+
+test('docs state non-interactive mode is CI or diagnostic, not guided onboarding', () => {
+  const docs = [
+    readFileSync('README.md', 'utf8'),
+    readFileSync('README.ko.md', 'utf8'),
+    readFileSync('docs/SETUP-CONFIG-GUIDE.md', 'utf8'),
+  ].join('\n');
+  assert.match(docs, /non-interactive.*CI.*diagnostic|CI.*diagnostic.*non-interactive|비대화형.*CI.*진단/i);
+  assert.match(docs, /not.*guided onboarding|guided onboarding.*not|가이드.*아님/i);
+});
+
+test('docs require superpowers availability or a clear next command', () => {
+  const docs = [
+    readFileSync('README.md', 'utf8'),
+    readFileSync('README.ko.md', 'utf8'),
+    readFileSync('docs/SETUP-CONFIG-GUIDE.md', 'utf8'),
+  ].join('\n');
+  assert.match(docs, /superpowers.*Next command|superpowers.*next command|superpowers.*다음 명령/i);
+  assert.match(docs, /\/using-superpowers/i);
+});

--- a/tests/init/cli.test.mjs
+++ b/tests/init/cli.test.mjs
@@ -73,7 +73,7 @@ test('doctor replays verify checks and prints ordered result', () => {
     encoding: 'utf8',
     env: { ...process.env, THISCODEX_REPO_ROOT: process.cwd(), HOME: home },
   });
-  assert.ok([0, 1, 2].includes(result.status));
+  assert.equal(result.status, 0, result.stdout + result.stderr);
   assert.match(result.stdout + result.stderr, /doctor|verify|BOT_WD|Codex/i);
   rmSync(dir, { recursive: true, force: true });
   rmSync(home, { recursive: true, force: true });

--- a/tests/init/cli.test.mjs
+++ b/tests/init/cli.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -90,10 +90,29 @@ test('non-TTY apply does not persist confirmed_* as check_only placeholder', () 
     env: { ...process.env, THISCODEX_REPO_ROOT: process.cwd(), HOME: home },
   });
   const statePath = join(home, '.config', 'thiscodex', 'install-state.json');
-  const state = JSON.parse(readFileSync(statePath, 'utf8'));
-  assert.notEqual(state.answers?.confirmed_bot_wd, 'check_only');
-  assert.notEqual(state.answers?.confirmed_state_dir, 'check_only');
-  assert.notEqual(state.answers?.confirmed_repo_root, 'check_only');
+  if (existsSync(statePath)) {
+    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+    assert.notEqual(state.answers?.confirmed_bot_wd, 'check_only');
+    assert.notEqual(state.answers?.confirmed_state_dir, 'check_only');
+    assert.notEqual(state.answers?.confirmed_repo_root, 'check_only');
+  }
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(home, { recursive: true, force: true });
+});
+
+test('non-interactive apply with yes but no answers stops before guided path persistence', () => {
+  const repo = mkdtempSync(join(tmpdir(), 'tcx-repo-'));
+  const home = mkdtempSync(join(tmpdir(), 'tcx-home-'));
+  const result = spawnSync(process.execPath, [BIN, 'init', '--apply', '--yes', '--non-interactive'], {
+    cwd: repo,
+    encoding: 'utf8',
+    input: '',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, THISCODEX_REPO_ROOT: process.cwd(), HOME: home },
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stdout + result.stderr, /Next command:/);
+  assert.equal(existsSync(join(home, '.config', 'thiscodex', 'install-state.json')), false);
   rmSync(repo, { recursive: true, force: true });
   rmSync(home, { recursive: true, force: true });
 });

--- a/tests/init/cli.test.mjs
+++ b/tests/init/cli.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -115,4 +115,43 @@ test('non-interactive apply with yes but no answers stops before guided path per
   assert.equal(existsSync(join(home, '.config', 'thiscodex', 'install-state.json')), false);
   rmSync(repo, { recursive: true, force: true });
   rmSync(home, { recursive: true, force: true });
+});
+
+test('answers file confirms guided paths and persists them explicitly', () => {
+  const repo = mkdtempSync(join(tmpdir(), 'tcx-repo-'));
+  const home = mkdtempSync(join(tmpdir(), 'tcx-home-'));
+  const workspace = mkdtempSync(join(tmpdir(), 'tcx-workspace-'));
+  const bot = mkdtempSync(join(tmpdir(), 'tcx-bot-'));
+  const stateDir = mkdtempSync(join(tmpdir(), 'tcx-state-'));
+  const answers = join(home, 'answers.json');
+  writeFileSync(answers, JSON.stringify({
+    install_surface: 'guided',
+    confirmed_repo_root: process.cwd(),
+    confirmed_workspace_root: workspace,
+    confirmed_bot_wd: bot,
+    confirmed_state_dir: stateDir,
+    codex_skill_layer: 'user',
+    codex_marketplace: 'no',
+    codex_yolo: 'safe',
+    alias_consent: 'no',
+    daemon_guide: 'no',
+  }));
+  const result = spawnSync(process.execPath, [BIN, 'init', '--apply', '--yes', '--answers', answers], {
+    cwd: repo,
+    encoding: 'utf8',
+    input: '',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, THISCODEX_REPO_ROOT: process.cwd(), HOME: home },
+  });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  const state = JSON.parse(readFileSync(join(home, '.config', 'thiscodex', 'install-state.json'), 'utf8'));
+  assert.equal(state.confirmed_repo_root, process.cwd());
+  assert.equal(state.confirmed_workspace_root, workspace);
+  assert.equal(state.confirmed_bot_wd, bot);
+  assert.equal(state.confirmed_state_dir, stateDir);
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(home, { recursive: true, force: true });
+  rmSync(workspace, { recursive: true, force: true });
+  rmSync(bot, { recursive: true, force: true });
+  rmSync(stateDir, { recursive: true, force: true });
 });

--- a/tests/init/doctor.test.mjs
+++ b/tests/init/doctor.test.mjs
@@ -58,6 +58,17 @@ test('rollout-materialized verify reads .codex-thread-id from BOT_WD', async () 
   rmSync(bot, { recursive: true, force: true });
 });
 
+test('superpowers verifier passes only when plugin path exists', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'tcx-home-'));
+  let result = await verifyStep({ verify: { type: 'superpowers-available' } }, {}, { HOME: home });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /superpowers/i);
+  mkdirSync(join(home, '.codex', 'plugins', 'cache', 'openai-curated', 'superpowers'), { recursive: true });
+  result = await verifyStep({ verify: { type: 'superpowers-available' } }, {}, { HOME: home });
+  assert.equal(result.ok, true);
+  rmSync(home, { recursive: true, force: true });
+});
+
 test('rollout-materialized skips with reason when no codex thread exists (CI-like)', async () => {
   const home = mkdtempSync(join(tmpdir(), 'tcx-home-'));
   const result = await verifyStep(

--- a/tests/init/flow-runner.test.mjs
+++ b/tests/init/flow-runner.test.mjs
@@ -31,7 +31,7 @@ test('runner obeys manifest order and verify gate', async () => {
 });
 
 test('runner stops on failed required step with next command', async () => {
-  const result = await runFlow({ steps, ctx: { mode: 'check', os: 'mac', answers: {}, tools: {} }, handlers: {
+  const result = await runFlow({ steps, ctx: { mode: 'apply', os: 'mac', answers: {}, tools: {} }, handlers: {
     action: async () => {},
     verify: async step => step.id === 'a' ? { ok: false, message: 'bad' } : { ok: true },
     explain: () => {},

--- a/tests/init/manifest.test.mjs
+++ b/tests/init/manifest.test.mjs
@@ -9,7 +9,9 @@ test('manifest loads ordered ThisCodex steps', () => {
   const ids = sortSteps(manifest.steps).map(s => s.id);
   for (const id of [
     'detect_environment',
+    'choose_install_surface',
     'confirm_repo_root',
+    'confirm_workspace_root',
     'confirm_bot_wd',
     'codex_skill_layer',
     'config_ceiling_patch',
@@ -19,6 +21,15 @@ test('manifest loads ordered ThisCodex steps', () => {
   ]) {
     assert.ok(ids.includes(id), `${id} missing`);
   }
+});
+
+test('manifest separates placement-only from guided onboarding', () => {
+  const manifest = loadManifest('install/thiscodex.install.json');
+  const ids = sortSteps(manifest.steps).map(s => s.id);
+  assert.ok(ids.includes('choose_install_surface'));
+  assert.ok(ids.includes('confirm_workspace_root'));
+  const surface = manifest.steps.find(s => s.id === 'choose_install_surface');
+  assert.equal(surface.verify.state_key, 'install_surface');
 });
 
 test('manifest validation rejects missing required fields', () => {

--- a/tests/init/prompts.test.mjs
+++ b/tests/init/prompts.test.mjs
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { promptForStep } from '../../scripts/lib/prompts.mjs';
+
+test('guided prompt is concrete and not the step id', () => {
+  const prompt = promptForStep({ id: 'confirm_bot_wd', reason: 'fallback' }, {
+    detected: { cwd: '/repo' },
+  });
+  assert.match(prompt.question, /bot working directory/i);
+  assert.doesNotMatch(prompt.question, /^confirm_bot_wd:/);
+  assert.equal(prompt.defaultValue, '/repo');
+});
+
+test('unknown prompt falls back to reason text', () => {
+  const prompt = promptForStep({ id: 'custom_step', reason: 'Explain custom step' }, { detected: {} });
+  assert.equal(prompt.question, 'Explain custom step');
+  assert.equal(prompt.defaultValue, '');
+});

--- a/tests/init/state.test.mjs
+++ b/tests/init/state.test.mjs
@@ -13,6 +13,9 @@ import {
   saveInstallState,
   confirmPath,
   rejectProvisionalPath,
+  freshInstallState,
+  withDetectedDefaults,
+  markPlacementOnly,
 } from '../../scripts/lib/state.mjs';
 
 test('fresh state skeleton', () => {
@@ -61,4 +64,21 @@ test('provisional paths are rejected before persistent state write', () => {
   const provisional = ['/', 'home', 'tofu', ['thiscodex', 'current', 'bot'].join('-')].join('/');
   assert.throws(() => rejectProvisionalPath(provisional), /provisional/);
   assert.doesNotThrow(() => rejectProvisionalPath('/home/alice/bots/sonseokhee'));
+});
+
+test('detected defaults do not become confirmed state', () => {
+  const state = freshInstallState();
+  const next = withDetectedDefaults(state, { repo_root: '/repo', cwd: '/tmp/bot' });
+  assert.equal(next.confirmed_repo_root, null);
+  assert.equal(next.confirmed_bot_wd, null);
+  assert.equal(next.detected.repo_root, '/repo');
+  assert.equal(next.detected.cwd, '/tmp/bot');
+});
+
+test('placement-only state does not persist guided confirmed paths', () => {
+  const state = markPlacementOnly(freshInstallState(), { skillLayer: 'user' });
+  assert.equal(state.placement_only, true);
+  assert.equal(state.confirmed_skill_layer, 'user');
+  assert.equal(state.confirmed_bot_wd, null);
+  assert.equal(state.confirmed_state_dir, null);
 });

--- a/tests/init/superpowers.test.mjs
+++ b/tests/init/superpowers.test.mjs
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectSuperpowers } from '../../scripts/lib/superpowers.mjs';
+
+test('detectSuperpowers reports missing plugin path with next command', () => {
+  const home = mkdtempSync(join(tmpdir(), 'tcx-home-'));
+  const result = detectSuperpowers({ HOME: home });
+  assert.equal(result.present, false);
+  assert.match(result.next_command, /superpowers|plugin/i);
+  rmSync(home, { recursive: true, force: true });
+});
+
+test('detectSuperpowers reports present plugin path', () => {
+  const home = mkdtempSync(join(tmpdir(), 'tcx-home-'));
+  mkdirSync(join(home, '.codex', 'plugins', 'cache', 'openai-curated', 'superpowers'), { recursive: true });
+  const result = detectSuperpowers({ HOME: home });
+  assert.equal(result.present, true);
+  assert.match(result.path, /superpowers$/);
+  rmSync(home, { recursive: true, force: true });
+});

--- a/tests/init/windows-sync.test.mjs
+++ b/tests/init/windows-sync.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  detectWindowsProfiles,
+  syncWindowsSkill,
+  verifyWindowsSkillSync,
+  windowsSkillPath,
+} from '../../scripts/lib/windows-sync.mjs';
+
+test('detectWindowsProfiles lists user directories under Windows root', () => {
+  const root = mkdtempSync(join(tmpdir(), 'tcx-win-'));
+  mkdirSync(join(root, 'Alice'), { recursive: true });
+  mkdirSync(join(root, 'Public'), { recursive: true });
+  assert.deepEqual(detectWindowsProfiles(root), [join(root, 'Alice'), join(root, 'Public')]);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('syncWindowsSkill copies thiscodex skill without deleting siblings', () => {
+  const root = mkdtempSync(join(tmpdir(), 'tcx-win-'));
+  const source = mkdtempSync(join(tmpdir(), 'tcx-skill-'));
+  const profile = join(root, 'Alice');
+  mkdirSync(profile, { recursive: true });
+  mkdirSync(join(profile, '.agents', 'skills', 'other'), { recursive: true });
+  writeFileSync(join(profile, '.agents', 'skills', 'other', 'SKILL.md'), 'keep');
+  writeFileSync(join(source, 'SKILL.md'), 'thiscodex skill');
+  const result = syncWindowsSkill({ sourceSkillDir: source, profileDir: profile });
+  assert.equal(result.dest, windowsSkillPath(profile));
+  assert.equal(readFileSync(join(result.dest, 'SKILL.md'), 'utf8'), 'thiscodex skill');
+  assert.equal(readFileSync(join(profile, '.agents', 'skills', 'other', 'SKILL.md'), 'utf8'), 'keep');
+  assert.equal(verifyWindowsSkillSync({ sourceSkillDir: source, profileDir: profile }).ok, true);
+  rmSync(root, { recursive: true, force: true });
+  rmSync(source, { recursive: true, force: true });
+});
+
+test('verifyWindowsSkillSync reports missing Windows skill', () => {
+  const source = mkdtempSync(join(tmpdir(), 'tcx-skill-'));
+  const profile = mkdtempSync(join(tmpdir(), 'tcx-profile-'));
+  writeFileSync(join(source, 'SKILL.md'), 'thiscodex skill');
+  const result = verifyWindowsSkillSync({ sourceSkillDir: source, profileDir: profile });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /Windows skill/i);
+  assert.equal(existsSync(windowsSkillPath(profile)), false);
+  rmSync(source, { recursive: true, force: true });
+  rmSync(profile, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- separate skill placement from full guided onboarding state
- add explicit confirmed-path handling, WSL Windows skill sync, and superpowers availability checks
- document guided onboarding semantics and keep doctor/CI behavior honest

## Verification
- npm test (91/91)
- node bin/thiscodex.mjs init --check --non-interactive
- node bin/thiscodex.mjs doctor --non-interactive
- git diff --check
- anchored secret scan: scan_count=0