### PR TITLE
feat: /test feature harness + Tofu symbol-mark

### DIFF
--- a/assets/SYMBOL-MARK.md
+++ b/assets/SYMBOL-MARK.md
@@ -1,0 +1,51 @@
+# Symbol Mark — "Tofu"
+
+A single character mark for the project, the way OpenClaw has its crab and
+Claude Code has its symbol. One character, used by **both** ThisCode and
+ThisCodex (they are companion runtimes of one system).
+
+## The character
+
+**Tofu** — a small, calm block of tofu with a friendly face and a tiny idea
+spark. It is deliberately plain and soft: the system's whole idea is *quiet,
+reliable helpers in the background*, not a loud robot.
+
+Why tofu:
+
+- It is the operator's long-running motif (the "말하는 두부 / 토푸경" writing
+  persona, the 두부 color palette already used in the beginner guide).
+- A block shape reads as a *building block* — the project's first-principles,
+  "assemble it from small pieces" stance.
+- Neutral and warm; it sits comfortably as a favicon, a README header, or a
+  Discord avatar.
+
+## Variants
+
+| File | Use |
+|---|---|
+| `symbol-mark.svg` | ThisCode (Claude side) — the base Tofu |
+| `symbol-mark-codex.svg` | ThisCodex (Codex side) — same Tofu, with a `</>` code bracket on the body to signal the code-verification companion |
+
+Same body, same palette, same character — only the chest mark differs, so the
+two repos are visibly one family.
+
+## Palette (두부 / beige — matches the beginner-guide typst tokens)
+
+| Token | Hex | Use |
+|---|---|---|
+| page beige | `#F3EAD7` | background plate |
+| tofu top | `#FFFDF4` | lit top face |
+| tofu front | `#FBF6EA` | front face |
+| tofu side | `#F1E7D0` | shaded side |
+| outline | `#6E5B43` | block edge |
+| face | `#5E4D38` | eyes / smile |
+| accent | `#C99A5B` | idea spark · codex bracket |
+
+## Usage notes
+
+- SVG is self-contained (no external fonts/refs) and scales cleanly; rasterize
+  at need (e.g. 512×512 PNG for a Discord avatar).
+- Keep the spark and (for the codex variant) the bracket in the accent color
+  only — that is the single brand accent; don't recolor the body.
+- If a future milestone wants motion (e.g. a blink), animate the two eye
+  circles only; the block stays still.

--- a/assets/symbol-mark-codex.svg
+++ b/assets/symbol-mark-codex.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="ThisCodex symbol mark — Tofu (code variant)">
+  <title>ThisCodex — Tofu symbol mark (code variant)</title>
+  <!-- Same Tofu character as ThisCode; the only difference is the chest mark
+       (a code bracket) signalling the Codex code-verification side. -->
+  <rect width="256" height="256" rx="44" fill="#F3EAD7"/>
+  <ellipse cx="128" cy="196" rx="74" ry="16" fill="#E2D4B6" opacity="0.55"/>
+  <g stroke="#6E5B43" stroke-width="6" stroke-linejoin="round">
+    <path d="M64 96 L128 70 L192 96 L128 122 Z" fill="#FFFDF4"/>
+    <path d="M64 96 L64 178 Q64 190 76 190 L116 190 L116 116 Z" fill="#FBF6EA"/>
+    <path d="M192 96 L192 178 Q192 190 180 190 L140 190 L140 116 Z" fill="#F1E7D0"/>
+    <path d="M116 116 L128 122 L140 116 L140 190 L116 190 Z" fill="#FBF6EA"/>
+  </g>
+  <g fill="#5E4D38">
+    <circle cx="95" cy="146" r="7"/>
+    <circle cx="161" cy="146" r="7"/>
+  </g>
+  <!-- code bracket "</>" on the body = the Codex variant marker -->
+  <g fill="none" stroke="#C99A5B" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M112 162 L102 172 L112 182"/>
+    <path d="M144 162 L154 172 L144 182"/>
+    <path d="M132 158 L124 186"/>
+  </g>
+  <g fill="#C99A5B">
+    <path d="M196 58 l5 13 13 5 -13 5 -5 13 -5 -13 -13 -5 13 -5 Z"/>
+  </g>
+</svg>

--- a/assets/symbol-mark.svg
+++ b/assets/symbol-mark.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="ThisCode symbol mark — Tofu">
+  <title>ThisCode — Tofu symbol mark</title>
+  <!-- Palette: 두부/beige, consistent with the project's tofu motif and the
+       typst beginner-guide tokens (warm beige page · creamy tofu · soft brown). -->
+  <rect width="256" height="256" rx="44" fill="#F3EAD7"/>
+  <!-- soft contact shadow -->
+  <ellipse cx="128" cy="196" rx="74" ry="16" fill="#E2D4B6" opacity="0.55"/>
+  <!-- tofu block: front face + a gentle top bevel for a soft 2.5D cube -->
+  <g stroke="#6E5B43" stroke-width="6" stroke-linejoin="round">
+    <path d="M64 96 L128 70 L192 96 L128 122 Z" fill="#FFFDF4"/>
+    <path d="M64 96 L64 178 Q64 190 76 190 L116 190 L116 116 Z" fill="#FBF6EA"/>
+    <path d="M192 96 L192 178 Q192 190 180 190 L140 190 L140 116 Z" fill="#F1E7D0"/>
+    <path d="M116 116 L128 122 L140 116 L140 190 L116 190 Z" fill="#FBF6EA"/>
+  </g>
+  <!-- face: calm, friendly, minimal -->
+  <g fill="#5E4D38">
+    <circle cx="95" cy="150" r="7"/>
+    <circle cx="161" cy="150" r="7"/>
+    <path d="M108 168 Q128 182 148 168" fill="none" stroke="#5E4D38" stroke-width="6" stroke-linecap="round"/>
+  </g>
+  <!-- idea spark: the "thinking helper" cue -->
+  <g fill="#C99A5B">
+    <path d="M196 58 l5 13 13 5 -13 5 -5 13 -5 -13 -13 -5 13 -5 Z"/>
+  </g>
+</svg>

--- a/scripts/feature-test.mjs
+++ b/scripts/feature-test.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const STATUS = {
+  PASS: 'PASS',
+  FAIL: 'FAIL',
+  SKIP: 'SKIP',
+};
+
+function normalize(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function fileExists(relPath) {
+  return existsSync(join(repoRoot, relPath));
+}
+
+function pass(message) {
+  return { status: STATUS.PASS, message };
+}
+
+function fail(message) {
+  return { status: STATUS.FAIL, message };
+}
+
+function skip(message) {
+  return { status: STATUS.SKIP, message };
+}
+
+function requireFiles(paths) {
+  const missing = paths.filter((relPath) => !fileExists(relPath));
+  if (missing.length > 0) {
+    return fail(`missing required file(s): ${missing.join(', ')}`);
+  }
+  return null;
+}
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    ...options,
+  });
+}
+
+function commandAvailable(command, args = ['--version']) {
+  const result = run(command, args);
+  return !result.error;
+}
+
+function compilePython(relPath) {
+  const missing = requireFiles([relPath]);
+  if (missing) return missing;
+  if (!commandAvailable('python3', ['--version'])) {
+    return skip('python3 unavailable; syntax smoke skipped');
+  }
+  const result = run('python3', ['-m', 'py_compile', relPath]);
+  if (result.status !== 0) {
+    return fail(`${relPath} failed py_compile`);
+  }
+  return pass(`${relPath} py_compile passed`);
+}
+
+function bashSyntax(paths) {
+  const missing = requireFiles(paths);
+  if (missing) return missing;
+  if (!commandAvailable('bash', ['--version'])) {
+    return skip('bash unavailable; shell syntax smoke skipped');
+  }
+  for (const relPath of paths) {
+    const result = run('bash', ['-n', relPath]);
+    if (result.status !== 0) {
+      return fail(`${relPath} failed bash -n`);
+    }
+  }
+  return pass(`${paths.length} hook shell file(s) passed bash -n`);
+}
+
+function parseJson(relPath) {
+  const missing = requireFiles([relPath]);
+  if (missing) return missing;
+  try {
+    JSON.parse(readFileSync(join(repoRoot, relPath), 'utf8'));
+    return pass(`${relPath} parses as JSON`);
+  } catch (error) {
+    return fail(`${relPath} JSON parse failed: ${error.message}`);
+  }
+}
+
+function countMarkdownFiles(relPath) {
+  try {
+    return readdirSync(join(repoRoot, relPath)).filter((name) => name.endsWith('.md')).length;
+  } catch {
+    return 0;
+  }
+}
+
+const FEATURES = [
+  {
+    id: 'memory',
+    aliases: ['memory', 'dreaming', 'archive', 'cold storage'],
+    run() {
+      return compilePython('scripts/memory_dreaming.py');
+    },
+  },
+  {
+    id: 'tmux',
+    aliases: ['tmux', 'terminal', 'pane', 'daemon'],
+    run() {
+      if (!commandAvailable('tmux', ['-V'])) {
+        return skip('tmux unavailable on this host');
+      }
+      return pass('tmux binary is available');
+    },
+  },
+  {
+    id: 'graphrag',
+    aliases: ['graphrag', 'graph rag', 'obsidian', 'vault search', 'graph'],
+    run() {
+      return compilePython('scripts/obsidian_cli_wrapper.py');
+    },
+  },
+  {
+    id: 'graphrag-bench',
+    aliases: ['graphrag bench', 'graph rag bench', 'benchmark', 'bench'],
+    run() {
+      const base = compilePython('scripts/obsidian_cli_wrapper.py');
+      if (base.status === STATUS.FAIL) return base;
+      if (process.env.THISCODEX_RUN_GRAPHRAG_BENCH !== '1') {
+        return skip('benchmark disabled; set THISCODEX_RUN_GRAPHRAG_BENCH=1 to run it');
+      }
+      return pass('benchmark prerequisites available');
+    },
+  },
+  {
+    id: 'meeting',
+    aliases: ['meeting', 'meeting protocol', 'watchdog', 'thread'],
+    run() {
+      const missing = requireFiles([
+        'docs/05-meeting-thread-protocol.md',
+        'rules/meeting-protocol.md',
+        'scripts/meeting_watchdog.py',
+      ]);
+      if (missing) return missing;
+      return compilePython('scripts/meeting_watchdog.py');
+    },
+  },
+  {
+    id: 'rules',
+    aliases: ['rules', 'rules system', 'meeting rules', 'index'],
+    run() {
+      const missing = requireFiles(['rules/INDEX.md', 'docs/rules-system.md']);
+      if (missing) return missing;
+      const count = countMarkdownFiles('rules');
+      if (count < 5) {
+        return fail(`rules directory has too few markdown files: ${count}`);
+      }
+      return pass(`rules directory has ${count} markdown file(s)`);
+    },
+  },
+  {
+    id: 'hooks',
+    aliases: ['hooks', 'session hook', 'stop hook', 'bot session'],
+    run() {
+      return bashSyntax(['hooks/bot-session-init.sh', 'hooks/meeting-stop-reread.sh']);
+    },
+  },
+  {
+    id: 'install',
+    aliases: ['install', 'installer', 'setup', 'manifest', 'init'],
+    run() {
+      const missing = requireFiles([
+        'bin/thiscodex.mjs',
+        'install/thiscodex.install.json',
+        'scripts/lib/manifest.mjs',
+        'scripts/lib/flow-runner.mjs',
+      ]);
+      if (missing) return missing;
+      return parseJson('install/thiscodex.install.json');
+    },
+  },
+];
+
+function scoreFeature(feature, query) {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) return 0;
+  const candidates = [feature.id, ...feature.aliases].map(normalize);
+  if (candidates.includes(normalizedQuery)) return 100;
+  if (normalizedQuery.split(' ').includes(normalize(feature.id))) return 90;
+  for (const candidate of candidates) {
+    if (normalizedQuery.includes(candidate) || candidate.includes(normalizedQuery)) return 80;
+    const words = candidate.split(' ').filter(Boolean);
+    if (words.length > 0 && words.every((word) => normalizedQuery.includes(word))) return 60;
+  }
+  return 0;
+}
+
+function selectFeatures(args) {
+  const includeBench = args.includes('--bench') || args.includes('all');
+  const query = args.filter((arg) => arg !== '--bench').join(' ').trim();
+  if (!query) {
+    return FEATURES.filter((feature) => includeBench || feature.id !== 'graphrag-bench');
+  }
+  if (normalize(query) === 'all') {
+    return FEATURES;
+  }
+
+  const ranked = FEATURES.map((feature) => ({
+    feature,
+    score: scoreFeature(feature, query),
+  }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.feature.id.localeCompare(b.feature.id));
+
+  if (ranked.length === 0) {
+    const known = FEATURES.map((feature) => feature.id).join(', ');
+    throw new Error(`unknown feature query: "${query}". Known features: ${known}`);
+  }
+  return [ranked[0].feature];
+}
+
+function runSelected(features) {
+  return features.map((feature) => {
+    let outcome;
+    try {
+      outcome = feature.run();
+    } catch (error) {
+      outcome = fail(error instanceof Error ? error.message : String(error));
+    }
+    return { id: feature.id, ...outcome };
+  });
+}
+
+function printResults(results) {
+  for (const result of results) {
+    console.log(`${result.status} ${result.id} - ${result.message}`);
+  }
+  const counts = {
+    PASS: results.filter((result) => result.status === STATUS.PASS).length,
+    FAIL: results.filter((result) => result.status === STATUS.FAIL).length,
+    SKIP: results.filter((result) => result.status === STATUS.SKIP).length,
+  };
+  console.log(
+    `Summary: PASS ${counts.PASS} / SKIP ${counts.SKIP} / FAIL ${counts.FAIL} / TOTAL ${results.length}`,
+  );
+  return counts.FAIL === 0 ? 0 : 1;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let selected;
+  try {
+    selected = selectFeatures(args);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+  const results = runSelected(selected);
+  return printResults(results);
+}
+
+process.exitCode = main();

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: test
+description: Run ThisCodex feature smoke tests through the /test dispatcher. Use when the user asks to test memory, tmux, GraphRAG, meetings, rules, hooks, or installer behavior.
+---
+
+# /test
+
+Use this skill for `/test` requests in ThisCodex.
+
+Run the repository harness from the repo root:
+
+```bash
+node scripts/feature-test.mjs [query]
+```
+
+Dispatch rules:
+
+- `/test` runs all lightweight features except `graphrag-bench`.
+- `/test <natural language>` fuzzy-matches one feature and runs only that smoke.
+- `/test graphrag-bench`, `/test --bench`, or `/test all` includes the benchmark entry.
+
+The harness prints compact per-feature `PASS`, `FAIL`, or `SKIP` rows plus a summary. Missing optional dependencies are `SKIP`; broken shipped files or syntax errors are `FAIL`.

--- a/tests/init/feature-test.test.mjs
+++ b/tests/init/feature-test.test.mjs
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const repoRoot = process.cwd();
+
+function runFeatureTest(args = []) {
+  return spawnSync(process.execPath, ['scripts/feature-test.mjs', ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+test('feature-test default run excludes the expensive graphrag benchmark', () => {
+  const result = runFeatureTest();
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = `${result.stdout}\n${result.stderr}`;
+  for (const id of ['memory', 'tmux', 'graphrag', 'meeting', 'rules', 'hooks', 'install']) {
+    assert.match(output, new RegExp(`\\b${id}\\b`));
+  }
+  assert.doesNotMatch(output, /\bgraphrag-bench\b/);
+  assert.match(output, /Summary:/);
+});
+
+test('feature-test dispatches a single fuzzy feature query', () => {
+  const result = runFeatureTest(['check', 'tmux', 'setup']);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /\btmux\b/);
+  assert.doesNotMatch(output, /\bmemory\b/);
+  assert.match(output, /Summary:/);
+});
+
+test('feature-test bench mode includes graphrag-bench', () => {
+  const result = runFeatureTest(['--bench']);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /\bgraphrag-bench\b/);
+  assert.match(output, /Summary:/);
+});
+
+test('/test skill entrypoint points at the feature-test harness', () => {
+  const skillPath = join(repoRoot, 'skills', 'test', 'SKILL.md');
+
+  assert.equal(existsSync(skillPath), true);
+  const body = readFileSync(skillPath, 'utf8').replace(/\r\n/g, '\n');
+  assert.match(body, /^name:\s*test$/m);
+  assert.match(body, /\/test/);
+  assert.match(body, /node scripts\/feature-test\.mjs/);
+});


### PR DESCRIPTION
- `/test` feature smoke harness (손석희, commit c2c46f8): scripts/feature-test.mjs
  + skills/test/SKILL.md + tests/init/feature-test.test.mjs. Contract parity
  with ThisCode (registry memory/tmux/graphrag/graphrag-bench/meeting/rules/
  hooks/install; no-arg=sweep excl bench; NL=one; all/--bench=incl; unknown→exit2).
  LOCK-verified independently: 3× deterministic (PASS 7 rc0), npm 118/118,
  rtk-free scan clean.
- Tofu symbol-mark assets (commit 9086a62) — brand parity with ThisCode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)