### PR TITLE
chore: bump plugin manifest + lockfile to v1.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thiscodex",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Make an OpenAI Codex CLI agent behave like a Claude Code Discord bot — persona/vault discipline, multi-agent conventions, progressive-disclosure rules, CC↔Codex skill portability.",
   "author": {
     "name": "treylom",

--- a/plugin.lock.json
+++ b/plugin.lock.json
@@ -2,7 +2,7 @@
   "lockVersion": 1,
   "plugin": {
     "name": "thiscodex",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "manifest": ".codex-plugin/plugin.json"
   },
   "sources": [


### PR DESCRIPTION
## Summary
- `.codex-plugin/plugin.json` version `0.1.0` → `1.0.0`
- `plugin.lock.json` plugin.version `0.1.0` → `1.0.0` (mirror sync with manifest)

## Why
package.json 은 지난 3-fix round 에서 1.0.0 bump 했지만 `.codex-plugin/plugin.json` + `plugin.lock.json` 만 0.1.0 잔존 — 정합 잔여 마무리.

## Test plan
- [ ] npm test 통과
- [ ] CI 全 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)