### PR TITLE
fix: clarify KM consumer boundaries for 1.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "description": "Make an OpenAI Codex CLI agent behave like a Claude Code Discord bot — persona/vault discipline, multi-agent conventions",
       "source": ".",
       "category": "developer-tools",
-      "version": "1.1.0"
+      "version": "1.1.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thiscodex",
   "description": "Make an OpenAI Codex CLI agent behave like a Claude Code Discord bot — persona/vault discipline, multi-agent conventions",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "tofukyung",
     "url": "https://github.com/treylom"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thiscodex",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Make an OpenAI Codex CLI agent behave like a Claude Code Discord bot — persona/vault discipline, multi-agent conventions, progressive-disclosure rules, CC↔Codex skill portability.",
   "author": {
     "name": "treylom",

--- a/docs/RECENT-CHANGES.md
+++ b/docs/RECENT-CHANGES.md
@@ -12,9 +12,9 @@
   files only. It does not install the separate Knowledge Manager plugin,
   `/km:search`, `/km:setup`, `km-config.json`, MCP entries, or search tiers.
 - The optional wiki path connects a save destination; it is not a second vault
-  search provider. The bundled vault bridge remains unchanged; the
-  compatibility contract now labels its current integration status without
-  changing its body, code, or API semantics.
+  search provider. The bundled vault bridge remains unchanged;
+  `docs/tool-equivalence-contract.md` now carries matching English/Korean status
+  notes without changing its contract body, code, or API behavior.
 - Package, Codex/Claude manifests, lock metadata, and marketplace metadata now
   agree on `1.1.1`.
 

--- a/docs/RECENT-CHANGES.md
+++ b/docs/RECENT-CHANGES.md
@@ -6,6 +6,20 @@
 > design doc. Newest first. Plain language; first use of a jargon term is
 > explained inline.
 
+## 2026-09-05 — vault product boundary clarified (1.1.1)
+
+- ThisCodex's Node installer owns ThisCodex skill placement and guided bot
+  files only. It does not install the separate Knowledge Manager plugin,
+  `/km:search`, `/km:setup`, `km-config.json`, MCP entries, or search tiers.
+- The optional wiki path connects a save destination; it is not a second vault
+  search provider. The bundled vault bridge remains unchanged; the
+  compatibility contract now labels its current integration status without
+  changing its body, code, or API semantics.
+- Package, Codex/Claude manifests, lock metadata, and marketplace metadata now
+  agree on `1.1.1`.
+
+---
+
 ## 2026-09-03 — plugin hooks bundle + one aggregate verifier (1.1.0)
 
 - The package, Codex/Claude manifests, lock metadata, and marketplace surface

--- a/docs/SETUP-CONFIG-GUIDE.md
+++ b/docs/SETUP-CONFIG-GUIDE.md
@@ -397,6 +397,12 @@ by default, repo-local `.agents/skills` when selected). ThisCodex intentionally
 does not ship a second shell sync script; duplicate sync paths drift and are
 harder to run on Windows.
 
+This installer does not install the separate Knowledge Manager plugin, its
+`/km:search` or `/km:setup` entry points, `km-config.json`, MCP entries, or
+GraphRAG/search tiers. The optional `wiki_path` above only connects a save
+destination. Use the Knowledge Manager plugin's own installer and setup for
+vault search; the ThisCode companion owns the local GraphRAG build/setup path.
+
 `scripts/launch.sh` remains a legacy/tmux fallback for operators who already
 run a bridge manually. New users should follow the Node runner guide. When
 `launch.sh` is used, set `THISCODEX_SHELL=${SHELL:-/bin/sh}` (or an explicit
@@ -412,7 +418,15 @@ zero-config default.
 
 ## §4 — How to set up & how to ask (first run)
 
-![4-Tier vault search with Obsidian-less degradation — GraphRAG → vault-search MCP → Obsidian CLI → ripgrep fallback](../assets/search-fallback-4tier.png)
+![Archived search illustration — GraphRAG → vault-search MCP → Obsidian CLI → ripgrep](../assets/search-fallback-4tier.png)
+
+The archived illustration uses an older tier order and qualitative support
+bars; it is not a current search contract or a measured quality comparison.
+It describes an optional connected stack, not a ThisCodex installer surface.
+The current fallback order is GraphRAG → Obsidian CLI →
+Obsidian MCP → ripgrep. ThisCodex does not install these tiers; `/km:search`
+and `/km:setup` are provided by the separate Knowledge Manager plugin, while
+the local GraphRAG build/setup path is in the ThisCode companion.
 
 Install per [README §Setup](../README.md) and [SKILL.md](../skills/thiscodex/SKILL.md)
 (register: `codex plugin marketplace add treylom/ThisCodex`; invoke via

--- a/docs/SETUP-CONFIG-GUIDE.md
+++ b/docs/SETUP-CONFIG-GUIDE.md
@@ -399,7 +399,7 @@ harder to run on Windows.
 
 This installer does not install the separate Knowledge Manager plugin, its
 `/km:search` or `/km:setup` entry points, `km-config.json`, MCP entries, or
-GraphRAG/search tiers. The optional `wiki_path` above only connects a save
+GraphRAG/search tiers. The installer's optional `wiki_path` answer only connects a save
 destination. Use the Knowledge Manager plugin's own installer and setup for
 vault search; the ThisCode companion owns the local GraphRAG build/setup path.
 
@@ -420,13 +420,11 @@ zero-config default.
 
 ![Archived search illustration — GraphRAG → vault-search MCP → Obsidian CLI → ripgrep](../assets/search-fallback-4tier.png)
 
-The archived illustration uses an older tier order and qualitative support
-bars; it is not a current search contract or a measured quality comparison.
-It describes an optional connected stack, not a ThisCodex installer surface.
-The current fallback order is GraphRAG → Obsidian CLI →
-Obsidian MCP → ripgrep. ThisCodex does not install these tiers; `/km:search`
-and `/km:setup` are provided by the separate Knowledge Manager plugin, while
-the local GraphRAG build/setup path is in the ThisCode companion.
+The archived illustration uses an older tier order and rough support markers;
+it is not a current search contract or a measured quality comparison.
+It shows optional connected tools, not something the ThisCodex installer sets up.
+The Knowledge Manager plugin documents its fallback order as GraphRAG →
+Obsidian CLI → Obsidian MCP → text search. For installer ownership, see §3 above.
 
 Install per [README §Setup](../README.md) and [SKILL.md](../skills/thiscodex/SKILL.md)
 (register: `codex plugin marketplace add treylom/ThisCodex`; invoke via

--- a/docs/graphrag-operations.md
+++ b/docs/graphrag-operations.md
@@ -7,6 +7,11 @@
 > *usage* discipline: [rules/search-usage.md](../rules/search-usage.md); tool
 > *selection*: [rules/knowledge-retrieval.md](../rules/knowledge-retrieval.md).
 >
+> This runbook is not an installer. The local GraphRAG build/setup files are in
+> the ThisCode companion; `/km:search` and `/km:setup` are entry points of the
+> separate Knowledge Manager plugin. ThisCodex documents the consumer-side
+> bridge and operating procedure for a search server that is already running.
+>
 > **Principle 1**: every command here must be copy-paste runnable.
 > **Principle 2 (model-independence contract)**: a new operator model must be
 > able to onboard from this doc + the design record alone. If that fails, the

--- a/docs/repo-handoff-install-contract.md
+++ b/docs/repo-handoff-install-contract.md
@@ -1,3 +1,9 @@
+---
+contract: repo-handoff-install-contract
+version: 0.1.0
+date: 2026-09-05
+---
+
 # Repo-Handoff Install Contract (ThisCode ⇄ ThisCodex — shared, normative)
 
 Canonical copy. Bundled into ThisCode as `contracts/repo-handoff-install-contract.md`.

--- a/docs/tool-equivalence-contract.md
+++ b/docs/tool-equivalence-contract.md
@@ -1,13 +1,12 @@
 # Tool-Equivalence Contract — Claude-only tools → Codex equivalents (no quality loss)
 
-> **Compatibility status (2026-09-05):** This document preserves the adapter
-> design and the wrapper/orchestrator APIs described below. The tracked
-> Knowledge Manager 1.4.0 source currently ships its own `.agent/skills`,
-> `commands`, and installers; it contains no `references/codex-adapter.md`
-> linkage to the ThisCodex wrapper or orchestrator. Treat the mappings and
-> smoke criteria below as compatibility design/history, not proof that the
-> current Knowledge Manager installation calls these ThisCodex files. No body,
-> code, or API semantics are changed by this status note.
+> **Compatibility status (2026-09-05):** This is a design/history record, not
+> a description of the current Knowledge Manager integration. The tracked
+> Knowledge Manager 1.4.0 source ships its own `.agent/skills`, `commands`, and
+> installers, with no `references/codex-adapter.md` linkage to the ThisCodex
+> wrapper or worker orchestrator. The mappings and smoke criteria below do not
+> prove that the current installation calls these files. This note preserves
+> the contract body, code, and API behavior.
 
 > Goal (maintainer directive, 2026-05-16): ThisCode skills (the
 > `knowledge-manager` family etc.) must migrate to Codex bots **without
@@ -231,6 +230,13 @@ unchanged.
 ---
 
 ## 한국어
+
+> **호환 상태 (2026-09-05):** 이 문서는 설계·이력 기록이며, 현재 Knowledge Manager의
+> 연결 방식을 설명하는 문서가 아닙니다. 추적 대상인 Knowledge Manager 1.4.0 소스에는
+> 자체 `.agent/skills`·`commands`·설치기가 있지만, ThisCodex의 wrapper나 worker
+> orchestrator로 연결하는 `references/codex-adapter.md`는 없습니다. 아래 매핑과
+> smoke 기준은 현재 설치가 이 파일들을 호출한다는 증거가 아닙니다.
+> 이 안내는 계약 본문·코드·API 동작을 바꾸지 않습니다.
 
 목표(maintainer 지시, 2026-05-16): ThisCode 스킬(`knowledge-manager` 계열 등)을 Codex
 봇으로 **품질손해 없이** 마이그레이션 — "노출했지만 저하"가 아님. 일부 KM

--- a/docs/tool-equivalence-contract.md
+++ b/docs/tool-equivalence-contract.md
@@ -1,5 +1,14 @@
 # Tool-Equivalence Contract — Claude-only tools → Codex equivalents (no quality loss)
 
+> **Compatibility status (2026-09-05):** This document preserves the adapter
+> design and the wrapper/orchestrator APIs described below. The tracked
+> Knowledge Manager 1.4.0 source currently ships its own `.agent/skills`,
+> `commands`, and installers; it contains no `references/codex-adapter.md`
+> linkage to the ThisCodex wrapper or orchestrator. Treat the mappings and
+> smoke criteria below as compatibility design/history, not proof that the
+> current Knowledge Manager installation calls these ThisCodex files. No body,
+> code, or API semantics are changed by this status note.
+
 > Goal (maintainer directive, 2026-05-16): ThisCode skills (the
 > `knowledge-manager` family etc.) must migrate to Codex bots **without
 > quality loss** — not "exposed but

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treylom/thiscodex",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Codex CLI Discord-bot installer, skills, rules, bridge contracts, and vault discipline.",
   "type": "module",
   "license": "MIT",

--- a/plugin.lock.json
+++ b/plugin.lock.json
@@ -2,7 +2,7 @@
   "lockVersion": 1,
   "plugin": {
     "name": "thiscodex",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "manifest": ".codex-plugin/plugin.json"
   },
   "sources": [

--- a/rules/knowledge-retrieval.md
+++ b/rules/knowledge-retrieval.md
@@ -3,6 +3,11 @@
 Trigger: about to search the project's own knowledge base / notes / docs
 (not arbitrary code, not the web).
 
+Provider boundary: this rule describes consumer-side routing only. It does not
+install or duplicate a knowledge provider. When the Knowledge Manager plugin
+is installed, `/km:search` and its fallback tiers remain that plugin's surface;
+the ThisCodex installer does not add them.
+
 ## 1. Pick the retrieval tool by query shape — don't raw-grep first
 Searching "our own docs" with a bare find/grep when a structured index
 exists is a regression (the curated store has better-than-grep retrieval).

--- a/rules/search-usage.md
+++ b/rules/search-usage.md
@@ -3,6 +3,11 @@
 Trigger: about to query the knowledge-base search (graph/semantic server or
 KB CLI); a search just failed or came back empty.
 
+Provider boundary: this file governs how a consumer uses an already-available
+search provider; it does not install or duplicate one. The Knowledge Manager
+plugin owns `/km:search` and its tiers when installed, while ThisCodex only
+ships its own bot/bridge installer.
+
 > Why: 2026-06-11 GraphRAG full audit (366-query server sample) — bots
 > converged on tool defaults (good), but exhibited (a) the same failed query
 > re-thrown 9 times in a row with no backoff, (b) ad-hoc weight overrides that

--- a/scripts/feature-test.mjs
+++ b/scripts/feature-test.mjs
@@ -126,6 +126,8 @@ const FEATURES = [
     id: 'graphrag',
     aliases: ['graphrag', 'graph rag', 'obsidian', 'vault search', 'graph'],
     run() {
+      // Compatibility name retained: this feature compiles the bundled vault
+      // wrapper only; it does not contact GraphRAG or run live vault E2E.
       return compilePython('scripts/obsidian_cli_wrapper.py');
     },
   },
@@ -138,7 +140,7 @@ const FEATURES = [
       if (process.env.THISCODEX_RUN_GRAPHRAG_BENCH !== '1') {
         return skip('benchmark disabled; set THISCODEX_RUN_GRAPHRAG_BENCH=1 to run it');
       }
-      return pass('benchmark prerequisites available');
+      return pass('benchmark prerequisites available; wrapper syntax smoke only, no live GraphRAG request');
     },
   },
   {

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: Use when running ThisCodex feature smoke tests through the /test dispatcher for memory, tmux, GraphRAG, meetings, rules, hooks, or installer behavior.
+description: Use when running ThisCodex feature smoke tests through the /test dispatcher for memory, tmux, the GraphRAG wrapper syntax smoke, meetings, rules, hooks, or installer behavior.
 ---
 
 # /test
@@ -20,8 +20,8 @@ Dispatch rules:
 | When to use | Call |
 |---|---|
 | Run all lightweight smoke tests | `/test` — runs memory, tmux, meetings, rules, hooks, installer smoke tests (excludes GraphRAG benchmark). Each test prints `PASS`, `FAIL`, or `SKIP`. |
-| Test a specific feature | `/test <feature name>` — fuzzy-matches one feature by name and runs that smoke test. Examples: `/test memory`, `/test meetings`, `/test graphrag`. |
-| Include GraphRAG benchmark | `/test graphrag-bench`, `/test --bench`, or `/test all` — includes the heavyweight GraphRAG indexing benchmark (slower, full-scope). |
+| Test a specific feature | `/test <feature name>` — fuzzy-matches one feature by name and runs that smoke test. Examples: `/test memory`, `/test meetings`, `/test graphrag` (bundled wrapper syntax smoke only; no live GraphRAG request). |
+| Include GraphRAG benchmark | `/test graphrag-bench`, `/test --bench`, or `/test all` — preserves the benchmark-compatible command, but the shipped feature currently checks wrapper syntax/prerequisites only and does not run live GraphRAG indexing. |
 | View test output | Test harness prints one row per feature (`PASS`/`FAIL`/`SKIP`) plus a summary line. Missing optional dependencies show `SKIP`; broken shipped files or syntax errors show `FAIL`. Exit code 0 = all passed or skipped; non-zero = ≥1 failed. |
 | Debug a failed test | Add `--verbose` flag for detailed logs: `/test --verbose` or `/test memory --verbose` for step-by-step output. |
 

--- a/tests/init/baseline.test.mjs
+++ b/tests/init/baseline.test.mjs
@@ -18,6 +18,9 @@ test('contract references both wrappers it ships with', () => {
   const c = readFileSync('docs/tool-equivalence-contract.md', 'utf8');
   assert.match(c, /obsidian_cli_wrapper\.py/);
   assert.match(c, /codex_worker_orchestrator\.py/);
+  const [english, korean] = c.split(/^## 한국어\s*$/m);
+  assert.match(english, /Compatibility status/);
+  assert.match(korean ?? '', /호환 상태/, 'the Korean entry point must include the same integration-status warning');
 });
 
 test('python baseline files compile', () => {

--- a/tests/init/cli.test.mjs
+++ b/tests/init/cli.test.mjs
@@ -457,7 +457,9 @@ test('answers file confirms guided paths and persists them explicitly', () => {
     { type: 'command', command: 'bash "/opt/vendor/keep.sh"' },
   ]);
   assert.equal(readdirSync(join(home, '.codex')).filter(name => name.endsWith('.bak')).length, 1);
-  assert.match(result.stdout, /codex plugin marketplace add .*ThisCodex/);
+  const marketplaceHint = result.stdout.split('\n').find(line => line.startsWith('Marketplace hint: '));
+  assert.ok(marketplaceHint?.includes('codex plugin marketplace add '), result.stdout);
+  assert.ok(marketplaceHint.includes(process.cwd()), 'marketplace hint must use the actual clone root');
   assert.doesNotMatch(result.stdout, /marketplace add .*\.codex-plugin/);
   assert.match(result.stdout, /codex plugin add thiscodex@thiscodex/);
   rmSync(repo, { recursive: true, force: true });

--- a/tests/init/codex-plugin-package.test.mjs
+++ b/tests/init/codex-plugin-package.test.mjs
@@ -56,7 +56,7 @@ test('release version is one value across package, manifests, lock, and marketpl
   const claude = JSON.parse(readFileSync('.claude-plugin/plugin.json', 'utf8'));
   const marketplace = JSON.parse(readFileSync('.claude-plugin/marketplace.json', 'utf8'));
   const lock = JSON.parse(readFileSync('plugin.lock.json', 'utf8'));
-  assert.equal(pkg.version, '1.1.0');
+  assert.equal(pkg.version, '1.1.1');
   assert.deepEqual(
     [plugin.version, claude.version, marketplace.plugins[0].version, lock.plugin.version],
     Array(4).fill(pkg.version),


### PR DESCRIPTION
## Summary

- Clarify ThisCodex's harness and consumer boundary with the external km plugin and optional ThisCode local-tool installers.
- Label the legacy adapter contract as compatibility design/history, and the old search illustration as archived rather than current or measured.
- Describe the GraphRAG-named feature check accurately as a Python wrapper syntax smoke check, not a live search test.
- Align five version surfaces at 1.1.1 and fix a CLI test that assumed a particular clone directory name.

## Validation

- `npm test`: 286 tests passed, no failures or skips. The baseline had one failure from the clone-name assumption.
- Focused package/CLI/feature checks and `git diff --check` passed.
- Independent review: GO for this safe, behavior-preserving scope.
- New private/jargon additions and token scan: zero matches, with positive/negative controls.

## Explicit retained exception

The legacy-pattern raw count is **1** in `docs/tool-equivalence-contract.md`, an existing variant name inside the retained adapter design. This is an approved design-history preservation exception, not a claim of a zero raw count.

The Obsidian wrapper, worker orchestrator, and their adapter contract remain unchanged in functionality pending a separate product decision on retirement or ownership. No merge, marketplace publication, live configuration change, or functional removal is included.
